### PR TITLE
More consistent handling of file formats in loadLocalImages

### DIFF
--- a/imagegraph/LeoGraphLib.py
+++ b/imagegraph/LeoGraphLib.py
@@ -145,7 +145,7 @@ def loadIIIFManifest(manifestURL, maxDownload=1000):
 
 def loadLocalImages(impaths='*.jpg', googleDrive=True, extensions=['jpg','png','gif','jpeg'] ):
 	
-	acceptedFileFormats = ['jpg','png','gif','jpeg','JPEG','JPG']
+	acceptedFileFormats = ['jpg','png','gif','jpeg','JPG','PNG','GIF','JPEG']
 	
 	if googleDrive:
 		try:

--- a/imagegraph/LeoGraphLib.py
+++ b/imagegraph/LeoGraphLib.py
@@ -143,7 +143,10 @@ def loadIIIFManifest(manifestURL, maxDownload=1000):
 				# print(imloc)
 	return imCollection
 
-def loadLocalImages(impaths='*.jpg', googleDrive=True ):
+def loadLocalImages(impaths='*.jpg', googleDrive=True, extensions=['jpg','png','gif','jpeg'] ):
+	
+	acceptedFileFormats = ['jpg','png','gif','jpeg','JPEG','JPG']
+	
 	if googleDrive:
 		try:
 			from google.colab import drive
@@ -154,8 +157,11 @@ def loadLocalImages(impaths='*.jpg', googleDrive=True ):
 				separator = '/*.'
 				if impaths[-1] == '/':
 					separator='*.'
-				for extension in ['jpg','png','gif','jpeg','JPEG','JPG']:
-					imfilelist += glob.glob('/content/drive/My Drive/' + impaths + separator+ extension, recursive=True)
+				for extension in extensions:
+					if extension not in acceptedFileFormats:
+						print('extension ' + extension + ' is not acceptable file format (' + acceptedFileFormats + ').')
+					else:
+						imfilelist += glob.glob('/content/drive/My Drive/' + impaths + separator + extension, recursive=True)
 			else:
 				imfilelist = glob.glob('/content/drive/My Drive/' + impaths, recursive=True)
 
@@ -166,8 +172,11 @@ def loadLocalImages(impaths='*.jpg', googleDrive=True ):
 				separator = '*/.'
 				if impaths[-1] == '/':
 					separator='*.'
-				for extension in ['jpg','png','gif','jpeg','JPEG','JPG']:
-					imfilelist += glob.glob( impaths + separator+ extension, recursive=True)
+				for extension in extensions:
+					if extension not in acceptedFileFormats:
+						print('extension ' + extension + ' is not acceptable file format (' + acceptedFileFormats + ').')
+					else:
+						imfilelist += glob.glob( impaths + separator + extension, recursive=True)
 			else:
 				imfilelist = glob.glob('/content/drive/My Drive/' + impaths, recursive=True)
 	else:
@@ -177,8 +186,11 @@ def loadLocalImages(impaths='*.jpg', googleDrive=True ):
 			separator = '*/.'
 			if impaths[-1] == '/':
 				separator='*.'
-			for extension in ['jpg','png','gif','jpeg','JPEG','JPG']:
-				imfilelist += glob.glob( impaths + separator+ extension, recursive=True)
+			for extension in extensions:
+				if extension not in acceptedFileFormats:
+					print('extension ' + extension + ' is not acceptable file format (' + acceptedFileFormats + ').')
+				else:
+					imfilelist += glob.glob( impaths + separator + extension, recursive=True)
 		else:
 			imfilelist = glob.glob(impaths, recursive=True)
 


### PR DESCRIPTION
Dear Leonardo,
I have been using ImageGraph with local 'jpg' files and realised that `loadLocalImages` was accounting for each file twice (as 'jpg' and 'JPG'). Maybe I missed a step in my workflow. In any case, I added a more consistent check of file formats that will avoid this problem altogether.
Thank you for your work,
Andreas